### PR TITLE
const / ref support for throwing version of any_cast

### DIFF
--- a/include/anyany.hpp
+++ b/include/anyany.hpp
@@ -739,32 +739,29 @@ template <typename T, any_x U>
 [[nodiscard]] PLEASE_INLINE const T* any_cast(const U* ptr) noexcept {
   static_assert(!(std::is_array_v<T> || std::is_function_v<T> || std::is_void_v<T>),
                 "Incorrect call, it will be always nullptr");
-  return caster::any_cast_impl<std::remove_cv_t<T>>(static_cast<typename U::base_any_type*>(ptr));
+  return caster::any_cast_impl<std::remove_cv_t<T>>(static_cast<const typename U::base_any_type*>(ptr));
 }
 
 template <typename T, any_x U>
 [[nodiscard]] std::remove_cv_t<T> any_cast(U& any) {
-  T* ptr = any_cast<T>(std::addressof(any));
+  auto* ptr = any_cast<std::remove_cvref_t<T>>(std::addressof(any));
   if (!ptr)
     throw std::bad_cast{};
-  std::remove_cv_t<T> result{*ptr};
-  return result;
+  return *ptr;
 }
 template <typename T, any_x U>
 [[nodiscard]] std::remove_cv_t<T> any_cast(U&& any) {
-  T* ptr = any_cast<T>(std::addressof(any));
+  auto* ptr = any_cast<std::remove_cvref_t<T>>(std::addressof(any));
   if (!ptr)
     throw std::bad_cast{};
-  std::remove_cv_t<T> result{std::move(*ptr)};
-  return result;
+  return std::move(*ptr);
 }
 template <typename T, any_x U>
 [[nodiscard]] std::remove_cv_t<T> any_cast(const U& any) {
-  T* ptr = any_cast<T>(std::addressof(any));
+  const auto* ptr = any_cast<std::remove_cvref_t<T>>(std::addressof(any));
   if (!ptr)
     throw std::bad_cast{};
-  std::remove_cv_t<T> result{*ptr};
-  return result;
+  return *ptr;
 }
 
 // TEMPLATE VARIABLE (FUNCTION OBJECT) invoke <Method> (any)

--- a/tests/test_anyany.cpp
+++ b/tests/test_anyany.cpp
@@ -384,6 +384,21 @@ size_t TestCasts() {
   error_if(aa::any_cast<std::vector<int>>(cp) != vec);
   error_if(aa::any_cast<std::vector<int>>(std::move(cp)) != vec);
   error_if(aa::any_cast<std::vector<int>>(cp) != std::vector<int>{});
+  {
+    any_copyable<> acop = 10;
+    auto& ref = aa::any_cast<int&>(acop);
+    ref = 15;
+    auto& ref2 = aa::any_cast<const int&>(acop);
+    int val = aa::any_cast<int>(acop);
+    (void)ref2, (void)val;
+  }
+  {
+    const any_copyable<> acop = 10;
+    //auto& ref = aa::any_cast<int&>(acop); CE because of const
+    auto& ref2 = aa::any_cast<const int&>(acop);
+    int val = aa::any_cast<int>(acop);
+    (void)ref2, (void)val;
+  }
   return error_count;
 }
 


### PR DESCRIPTION
it was originally supposed that if you need a reference, then you will use the pointer-returning version, but it seems that nothing bad will happen if you allow you to cast directly to the reference.
In addition, a compilation error was fixed when casting from a constant any to a non-constant type