### PR TITLE
gcc build fix

### DIFF
--- a/include/anyany.hpp
+++ b/include/anyany.hpp
@@ -875,7 +875,7 @@ struct invoke_unsafe_fn<Method, type_list<Args...>> {
 
 // for cases, when you sure any has value (so UB if !has_value), compilers bad at optimizations(
 template <TTA Method>
-constexpr inline invoke_unsafe_fn<Method, args_list<Method>> invoke_unsafe{};
+constexpr inline invoke_unsafe_fn<Method> invoke_unsafe = {};
 
 // CRTP - inheritor of basic_any
 // SooS == Small Object Optimization Size
@@ -1333,7 +1333,7 @@ struct invoke_fn<Method, type_list<Args...>> {
 };
 
 template <TTA Method>
-constexpr inline invoke_fn<Method, args_list<Method>> invoke{};
+constexpr inline invoke_fn<Method> invoke = {};
 
 // Strong alias to basic_any with Alloc, SooS and Methods..., used to cover CRTP
 template <typename Alloc, size_t SooS, TTA... Methods>

--- a/include/anyany.hpp
+++ b/include/anyany.hpp
@@ -875,7 +875,7 @@ struct invoke_unsafe_fn<Method, type_list<Args...>> {
 
 // for cases, when you sure any has value (so UB if !has_value), compilers bad at optimizations(
 template <TTA Method>
-constexpr inline invoke_unsafe_fn<Method> invoke_unsafe{};
+constexpr inline invoke_unsafe_fn<Method, args_list<Method>> invoke_unsafe{};
 
 // CRTP - inheritor of basic_any
 // SooS == Small Object Optimization Size
@@ -1333,7 +1333,7 @@ struct invoke_fn<Method, type_list<Args...>> {
 };
 
 template <TTA Method>
-constexpr inline invoke_fn<Method> invoke{};
+constexpr inline invoke_fn<Method, args_list<Method>> invoke{};
 
 // Strong alias to basic_any with Alloc, SooS and Methods..., used to cover CRTP
 template <typename Alloc, size_t SooS, TTA... Methods>

--- a/include/anyany.hpp
+++ b/include/anyany.hpp
@@ -875,7 +875,7 @@ struct invoke_unsafe_fn<Method, type_list<Args...>> {
 
 // for cases, when you sure any has value (so UB if !has_value), compilers bad at optimizations(
 template <TTA Method>
-constexpr invoke_unsafe_fn<Method> invoke_unsafe = {};
+constexpr inline invoke_unsafe_fn<Method> invoke_unsafe{};
 
 // CRTP - inheritor of basic_any
 // SooS == Small Object Optimization Size
@@ -1332,9 +1332,8 @@ struct invoke_fn<Method, type_list<Args...>> {
   }
 };
 
-
 template <TTA Method>
-constexpr invoke_fn<Method> invoke = {};
+constexpr inline invoke_fn<Method> invoke{};
 
 // Strong alias to basic_any with Alloc, SooS and Methods..., used to cover CRTP
 template <typename Alloc, size_t SooS, TTA... Methods>

--- a/tests/test_anyany.cpp
+++ b/tests/test_anyany.cpp
@@ -377,14 +377,10 @@ using xyz = aa::basic_any_with<std::allocator<std::byte>, 0, aa::copy_with<std::
 // EXAMPLE WITH POLYMORPHIC_PTR
 template<typename T>
 struct Drawi {
-  static constexpr bool good = requires(T value, int out) {
-    value.draw(out);
-  };
-  static auto do_invoke(const T& self, int val) requires(good)
+  static int do_invoke(const T& self, int val)
   {
     return self.draw(val);
   }
-  static int do_invoke(aa::interface_t, int) requires(!good);
 
   template<typename CRTP>
   struct plugin {


### PR DESCRIPTION
gcc cannot understand this code(foo is not overloaded)
```cpp
template<typename T>
struct S {
    static void foo() requires (!X<T>);
    static void foo() requires (X<T>);
};
int main() {
  &S<int>::foo;
}
```