### PR TITLE
Optimizing trivial move/destroy/copy

### DIFF
--- a/include/anyany/anyany.hpp
+++ b/include/anyany/anyany.hpp
@@ -1383,6 +1383,7 @@ struct basic_any : construct_interface<basic_any<Alloc, SooS, Methods...>, Metho
     // when allocates stores in size in unused buffer
     return size_allocated;
   }
+  // precondition - has_value() == true
   void destroy_value() noexcept {
     invoke<destroy> (*this)(value_ptr);
     if (memory_allocated()) {

--- a/include/anyany/anyany.hpp
+++ b/include/anyany/anyany.hpp
@@ -196,7 +196,7 @@ struct move {
   static AA_CONSTEVAL_CPP20 auto do_value() noexcept
       -> std::enable_if_t<(std::is_move_constructible_v<T> && std::is_nothrow_destructible_v<T>),
                           value_type> {
-    if constexpr (!noexport::is_fits_in_soo_buffer<T, std::numeric_limits<size_t>::max()>)
+    if constexpr (!noexport::is_fits_in_soo_buffer<T, static_cast<size_t>(-1)>)
       return nullptr;  // never called if value on heap
     // reduces count of functions as possible, because compiler cannot optimize them
     if constexpr (std::is_empty_v<T> && std::is_trivially_copyable_v<T> &&

--- a/include/anyany/noexport/anyany_details.hpp
+++ b/include/anyany/noexport/anyany_details.hpp
@@ -3,6 +3,9 @@
 #include <cstddef>
 #include <type_traits>
 #include <utility>  // forward
+#ifdef AA_HAS_CPP20
+#include <memory>   // construct_at/destroy_at
+#endif
 
 #include "common.hpp"
 
@@ -151,7 +154,7 @@ template <typename Needle, typename Haystack>
 AA_CONSTEVAL_CPP20 bool has_subsequence(Needle needle, Haystack haystack) {
   return find_subsequence(needle, haystack) != aa::npos;
 }
-
+#ifndef AA_HAS_CPP20
 template <typename T, typename... Args,
           typename = std::void_t<decltype(::new(std::declval<void*>()) T(std::declval<Args>()...))>>
 constexpr T* construct_at(const T* location, Args&&... args) noexcept(noexcept(
@@ -163,6 +166,10 @@ template <typename T>
 constexpr void destroy_at(const T* location) noexcept {
   location->~T();
 }
+#else
+using std::construct_at;
+using std::destroy_at;
+#endif
 
 template <typename T>
 using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
@@ -216,16 +223,91 @@ constexpr inline bool is_fits_in_soo_buffer =
 
 // precondition !!src && !!dest
 template <typename T>
-AA_ALWAYS_INLINE void relocate(T* src, T* dest) noexcept {
-  if constexpr (std::is_nothrow_move_constructible_v<T>) {
-    static_assert(noexcept((*src).~T()));
-    noexport::construct_at(dest, std::move(*src));
-    noexport::destroy_at(src);
+void relocate(void* _src, void* _dest) noexcept {
+  T* src = reinterpret_cast<T*>(_src);
+  T* dest = reinterpret_cast<T*>(_dest);
+  noexport::construct_at(dest, std::move(*src));
+  noexport::destroy_at(src);
+}
+// precondition: 'dest' do not contain object, so never overlaps with 'src'
+// used by 'move', 'copy_with' methods
+// to reduce count of functions from CountOfTypes to
+// CountOfDifferentSizeofs
+template<size_t Sizeof>
+void relocate_trivial(void* src, void* dest) noexcept {
+  // memcpy inlined and optimized by gcc/clang
+  std::memcpy(dest, src, Sizeof);
+}
+
+// preconditions:
+//    * no object under 'dest'
+//    * atleast 'SooS' bytes under 'dest' and alignment == alignof(std::max_align_t)
+//    * there are 'Alloc' object under 'alloc_' (void* here to make other copy funtions alloc independent)
+// postconditions:
+//    * returns pointer to created copy
+//    * if return != 'dest', then value was allocated by 'alloc' and allocation size storoed under
+//    'dest'(size_t)
+template <typename T, typename Alloc, size_t SooS>
+static void* copy_fn(const void* src_raw, void* dest, void* alloc_) {
+  static_assert(SooS >= sizeof(size_t));
+  Alloc& alloc = *reinterpret_cast<Alloc*>(alloc_);
+  const T& src = *reinterpret_cast<const T*>(src_raw);
+  if constexpr (noexport::is_fits_in_soo_buffer<T, SooS>) {
+    return noexport::construct_at(reinterpret_cast<T*>(dest), src);
   } else {
-    // never called if type is throw movable, but i need to compile Method
-    // So this 'if constexpr' removes never used code in binary
-    AA_UNREACHABLE;
+    constexpr size_t allocation_size = sizeof(T);
+    // no fancy pointers supported
+    auto* ptr = alloc.allocate(allocation_size);
+    if constexpr (std::is_nothrow_copy_constructible_v<T>) {
+      noexport::construct_at(reinterpret_cast<T*>(ptr), src);
+    } else {
+      try {
+        noexport::construct_at(reinterpret_cast<T*>(ptr), src);
+      } catch (...) {
+        alloc.deallocate(ptr, allocation_size);
+        throw;
+      }
+    }
+    noexport::construct_at(reinterpret_cast<std::size_t*>(dest), allocation_size);
+    return ptr;
   }
+}
+template <typename T, typename Alloc, size_t SooS>
+static void* copy_fn_empty_alloc(const void* src_raw, void* dest) {
+  Alloc a{};
+  return copy_fn<T, Alloc, SooS>(src_raw, dest, std::addressof(a));
+}
+
+static void* noop_copy_fn(const void*, void* dest, void*) noexcept {
+  return dest;
+}
+static void* noop_copy_fn_empty_alloc(const void* src_raw, void* dest) noexcept {
+  return noop_copy_fn(src_raw, dest, nullptr);
+}
+
+template <size_t Sizeof>
+static void* trivial_copy_small_fn(const void* src_raw, void* dest, void*) noexcept {
+  std::memcpy(dest, src_raw, Sizeof);
+  return dest;
+}
+template <size_t Sizeof>
+static void* trivial_copy_small_fn_empty_alloc(const void* src_raw, void* dest) {
+  return trivial_copy_small_fn<Sizeof>(src_raw, dest, nullptr);
+}
+
+template <size_t Sizeof, typename Alloc>
+static void* trivial_copy_big_fn(const void* src_raw, void* dest, void* alloc_) {
+  static_assert(is_byte_like<typename Alloc::value_type>);
+  Alloc& alloc = *reinterpret_cast<Alloc*>(alloc_);
+  void* result = alloc.allocate(Sizeof);
+  std::memcpy(result, src_raw, Sizeof);
+  noexport::construct_at(reinterpret_cast<size_t*>(dest), Sizeof);
+  return result;
+}
+template <size_t Sizeof, typename Alloc>
+static void* trivial_copy_big_fn_empty_alloc(const void* src_raw, void* dest) {
+  Alloc a{};
+  return trivial_copy_big_fn<Sizeof, Alloc>(src_raw, dest, std::addressof(a));
 }
 
 template <typename... Ts, typename T>

--- a/include/anyany/noexport/anyany_details.hpp
+++ b/include/anyany/noexport/anyany_details.hpp
@@ -240,6 +240,11 @@ void relocate_trivial(void* src, void* dest) noexcept {
   std::memcpy(dest, src, Sizeof);
 }
 
+template<typename Alloc>
+AA_CONSTEVAL_CPP20 bool copy_requires_alloc() {
+  return !(std::is_empty_v<Alloc> && std::is_default_constructible_v<Alloc>);
+}
+
 // preconditions:
 //    * no object under 'dest'
 //    * atleast 'SooS' bytes under 'dest' and alignment == alignof(std::max_align_t)

--- a/include/anyany/noexport/anyany_details.hpp
+++ b/include/anyany/noexport/anyany_details.hpp
@@ -3,6 +3,7 @@
 #include <cstddef>
 #include <type_traits>
 #include <utility>  // forward
+#include <cstring>  // memcpy
 #ifdef AA_HAS_CPP20
 #include <memory>   // construct_at/destroy_at
 #endif

--- a/include/anyany/noexport/anyany_details.hpp
+++ b/include/anyany/noexport/anyany_details.hpp
@@ -298,7 +298,7 @@ static void* trivial_copy_small_fn_empty_alloc(const void* src_raw, void* dest) 
 
 template <size_t Sizeof, typename Alloc>
 static void* trivial_copy_big_fn(const void* src_raw, void* dest, void* alloc_) {
-  static_assert(is_byte_like<typename Alloc::value_type>);
+  static_assert(is_byte_like_v<typename Alloc::value_type>);
   Alloc& alloc = *reinterpret_cast<Alloc*>(alloc_);
   void* result = alloc.allocate(Sizeof);
   std::memcpy(result, src_raw, Sizeof);

--- a/include/anyany/noexport/anyany_details.hpp
+++ b/include/anyany/noexport/anyany_details.hpp
@@ -4,9 +4,6 @@
 #include <type_traits>
 #include <utility>  // forward
 #include <cstring>  // memcpy
-#ifdef AA_HAS_CPP20
-#include <memory>   // construct_at/destroy_at
-#endif
 
 #include "common.hpp"
 
@@ -155,22 +152,18 @@ template <typename Needle, typename Haystack>
 AA_CONSTEVAL_CPP20 bool has_subsequence(Needle needle, Haystack haystack) {
   return find_subsequence(needle, haystack) != aa::npos;
 }
-#ifndef AA_HAS_CPP20
+
 template <typename T, typename... Args,
           typename = std::void_t<decltype(::new(std::declval<void*>()) T(std::declval<Args>()...))>>
-constexpr T* construct_at(const T* location, Args&&... args) noexcept(noexcept(
+AA_ALWAYS_INLINE constexpr T* construct_at(const T* location, Args&&... args) noexcept(noexcept(
     ::new(const_cast<void*>(static_cast<const volatile void*>(location))) T(std::forward<Args>(args)...))) {
   return ::new (const_cast<void*>(static_cast<const volatile void*>(location)))
       T(std::forward<Args>(args)...);
 }
 template <typename T>
-constexpr void destroy_at(const T* location) noexcept {
+AA_ALWAYS_INLINE constexpr void destroy_at(const T* location) noexcept {
   location->~T();
 }
-#else
-using std::construct_at;
-using std::destroy_at;
-#endif
 
 template <typename T>
 using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;

--- a/tests/test_anyany.cpp
+++ b/tests/test_anyany.cpp
@@ -790,7 +790,7 @@ void anyany_concepts_test() {
   static_assert(!aa::regular_method<void>);
   static_assert(!aa::const_method<void>);
   static_assert(!aa::const_method<int>);
-  static_assert(!aa::const_method<aa::move>);
+  static_assert(aa::const_method<aa::move>);
   static_assert(aa::const_method<aa::copy>);
   static_assert(aa::const_method<aa::destroy>);
   static_assert(aa::const_method<print>);

--- a/tests/test_anyany.cpp
+++ b/tests/test_anyany.cpp
@@ -204,8 +204,6 @@ TEST(constructors) {
       return i * 2;
     }
   };
-  // TODO улучшить этот тест чекая всё что надо
-  // TODO отметить, что подобная оптимизация размера бинарника невозможна на виртуальных функциях
   boobl bval;
   aa::any_with<boo> l{std::in_place_type<aa::poly_ref<boo>>, bval};
   error_if(l.boo(15) != 30);


### PR DESCRIPTION
Let N trivially destructible types. Now i forced to create N functions which do exactly nothing to store them in vtable.
Compiler cannot optimize them or even reduce binary object size(for guarantee, that addresses are not equal).

So if i create one 'trivial_destroy' function, all trivially desctructible types in programm will use it(more cache friendly) + no useless functions in binary(less binary size)
Same logic can be applied to move and copy Methods

Im not adding nullptr in vtable, because it provoces 'if' in some places, reducing performance for non trivial types

On local test .exe (with many anyany tests) this reduces binary size on x64 release clang from 364 KB to 323 KB