### PR TITLE
interface alias support

### DIFF
--- a/include/anyany/anyany.hpp
+++ b/include/anyany/anyany.hpp
@@ -1324,40 +1324,47 @@ struct basic_any : construct_interface<basic_any<Alloc, SooS, Methods...>, Metho
       : basic_any(force_stable_pointers, std::in_place_type<std::decay_t<T>>, std::forward<T>(value)) {
   }
 
-  void swap(basic_any& other) noexcept {
-    using std::swap;
-    auto swap_one_allocated_case = [](basic_any& a, basic_any& b) {
-      // assumes 'a'.allocated value and 'b' - no
-      size_t allocated_bytes_count = a.size_allocated;
-      b.get_move_fn()(b.value_ptr, a.data);
-      b.value_ptr = std::exchange(a.value_ptr, a.data);
-      b.size_allocated = allocated_bytes_count;
-    };
-    if (memory_allocated()) {
-      if (other.memory_allocated()) {
-        swap(value_ptr, other.value_ptr);
-        swap(size_allocated, other.size_allocated);
-      } else {
-        swap_one_allocated_case(*this, other);
-      }
-    } else { // !this->memory_allocated()
-      if (other.memory_allocated()) {
-        swap_one_allocated_case(other, *this);
-      } else { // case when two on local storage
-        alignas(std::max_align_t) std::byte tmp[SooS];
-        auto* other_move_fn = other.get_move_fn();
-        other_move_fn(other.value_ptr, tmp);
-        get_move_fn()(value_ptr, other.data);
-        other_move_fn(tmp, data);
-      }
-    }
+ private:
+  // precondition: a.memory_allocated() && !b.memory_allocated() && b.has_value()
+  static AA_ALWAYS_INLINE void swap_heap_local_case(basic_any& a, basic_any& b) noexcept {
+    [[assume(a.memory_allocated())]];
+    [[assume(!b.memory_allocated())]];
+    [[assume(b.has_value())]];
+    const size_t allocated_bytes_count = a.size_allocated;
+    b.get_move_fn()(b.data, a.data);
+    b.value_ptr = std::exchange(a.value_ptr, a.data);
+    b.size_allocated = allocated_bytes_count;
+  }
+
+ public:
+  constexpr void swap(basic_any& other) noexcept {
+    if (!has_value()) [[unlikely]]
+      return (void)(*this = std::move(other));
+    else if (!other.has_value()) [[unlikely]]
+      return (void)(other = std::move(*this));
     if constexpr (!alloc_traits::is_always_equal::value && alloc_traits::propagate_on_container_swap::value) {
+      using std::swap;
       if (alloc != other.alloc)
         swap(alloc, other.alloc);
     }
-    swap(vtable_ptr, other.vtable_ptr);
+    const bool ma1 = memory_allocated();
+    const bool ma2 = other.memory_allocated();
+    if (!ma1 && !ma2) {
+      alignas(std::max_align_t) std::byte tmp[SooS];
+      const auto other_move_fn = other.get_move_fn();
+      other_move_fn(other.value_ptr, tmp);
+      get_move_fn()(value_ptr, other.data);
+      other_move_fn(tmp, data);
+    } else if (ma1 && ma2) {
+      std::swap(value_ptr, other.value_ptr);
+      std::swap(size_allocated, other.size_allocated);
+    } else if (ma1)
+      swap_heap_local_case(*this, other);
+    else  // ma2 == true
+      swap_heap_local_case(other, *this);
+    std::swap(vtable_ptr, other.vtable_ptr);
   }
-  friend void swap(basic_any& a, basic_any& b) noexcept {
+  friend constexpr void swap(basic_any& a, basic_any& b) noexcept {
     a.swap(b);
   }
   // postconditions : has_value() == false

--- a/include/anyany/anyany.hpp
+++ b/include/anyany/anyany.hpp
@@ -1324,49 +1324,6 @@ struct basic_any : construct_interface<basic_any<Alloc, SooS, Methods...>, Metho
       : basic_any(force_stable_pointers, std::in_place_type<std::decay_t<T>>, std::forward<T>(value)) {
   }
 
- private:
-  // precondition: a.memory_allocated() && !b.memory_allocated() && b.has_value()
-  static AA_ALWAYS_INLINE void swap_heap_local_case(basic_any& a, basic_any& b) noexcept {
-    [[assume(a.memory_allocated())]];
-    [[assume(!b.memory_allocated())]];
-    [[assume(b.has_value())]];
-    const size_t allocated_bytes_count = a.size_allocated;
-    b.get_move_fn()(b.data, a.data);
-    b.value_ptr = std::exchange(a.value_ptr, a.data);
-    b.size_allocated = allocated_bytes_count;
-  }
-
- public:
-  constexpr void swap(basic_any& other) noexcept {
-    if (!has_value()) [[unlikely]]
-      return (void)(*this = std::move(other));
-    else if (!other.has_value()) [[unlikely]]
-      return (void)(other = std::move(*this));
-    if constexpr (!alloc_traits::is_always_equal::value && alloc_traits::propagate_on_container_swap::value) {
-      using std::swap;
-      if (alloc != other.alloc)
-        swap(alloc, other.alloc);
-    }
-    const bool ma1 = memory_allocated();
-    const bool ma2 = other.memory_allocated();
-    if (!ma1 && !ma2) {
-      alignas(std::max_align_t) std::byte tmp[SooS];
-      const auto other_move_fn = other.get_move_fn();
-      other_move_fn(other.value_ptr, tmp);
-      get_move_fn()(value_ptr, other.data);
-      other_move_fn(tmp, data);
-    } else if (ma1 && ma2) {
-      std::swap(value_ptr, other.value_ptr);
-      std::swap(size_allocated, other.size_allocated);
-    } else if (ma1)
-      swap_heap_local_case(*this, other);
-    else  // ma2 == true
-      swap_heap_local_case(other, *this);
-    std::swap(vtable_ptr, other.vtable_ptr);
-  }
-  friend constexpr void swap(basic_any& a, basic_any& b) noexcept {
-    a.swap(b);
-  }
   // postconditions : has_value() == false
   void reset() noexcept {
     if (!has_value())

--- a/include/anyany/anyany.hpp
+++ b/include/anyany/anyany.hpp
@@ -101,7 +101,7 @@ concept simple_method = regular_method<T> || pseudomethod<T>;
 namespace noexport {
 
 template <typename... Methods>
-consteval bool all_methods_are_simple(type_list<Methods...>) {
+consteval bool all_types_are_simple_methods(type_list<Methods...>) {
   return (simple_method<Methods> && ...);
 }
 
@@ -109,7 +109,7 @@ consteval bool all_methods_are_simple(type_list<Methods...>) {
 
 template<typename T>
 concept compound_method = (!regular_method<T> && !pseudomethod<T> && noexport::is_type_list<T>::value &&
-                           noexport::all_methods_are_simple(T{}));
+                           noexport::all_types_are_simple_methods(T{}));
 
 template <typename T>
 concept method = simple_method<T> || compound_method<T>;

--- a/include/anyany/noexport/anyany_details.hpp
+++ b/include/anyany/noexport/anyany_details.hpp
@@ -9,6 +9,12 @@
 
 #include "file_begin.hpp"
 
+namespace aa {
+
+constexpr inline size_t npos = size_t(-1);
+
+}  // namespace aa
+
 namespace aa::noexport {
 
 template <typename T>
@@ -277,10 +283,10 @@ static void* copy_fn_empty_alloc(const void* src_raw, void* dest) {
   return copy_fn<T, Alloc, SooS>(src_raw, dest, std::addressof(a));
 }
 
-static void* noop_copy_fn(const void*, void* dest, void*) noexcept {
+inline void* noop_copy_fn(const void*, void* dest, void*) noexcept {
   return dest;
 }
-static void* noop_copy_fn_empty_alloc(const void* src_raw, void* dest) noexcept {
+inline void* noop_copy_fn_empty_alloc(const void* src_raw, void* dest) noexcept {
   return noop_copy_fn(src_raw, dest, nullptr);
 }
 

--- a/include/anyany/noexport/anyany_details.hpp
+++ b/include/anyany/noexport/anyany_details.hpp
@@ -339,12 +339,11 @@ constexpr bool contains_second_layer_list(aa::type_list<Ts...>) {
   return (is_type_list<Ts>::value || ...);
 }
 template <typename... Types>
-auto flatten_types(aa::type_list<Types...>) {
-  using step = flatten_type_lists_one_layer<Types...>;
-  if constexpr (contains_second_layer_list(step{}))
-    return flatten_types(step{});
+auto flatten_types(aa::type_list<Types...> list) {
+  if constexpr (contains_second_layer_list(list))
+    return flatten_types(flatten_type_lists_one_layer<Types...>{});
   else
-    return step{};
+    return list;
 }
 template <typename... Ts>
 using flatten_types_t = decltype(flatten_types(aa::type_list<Ts...>{}));

--- a/include/anyany/noexport/common.hpp
+++ b/include/anyany/noexport/common.hpp
@@ -9,8 +9,6 @@ using erased_self_t = int;
 template <typename...>
 struct type_list {};
 
-constexpr inline size_t npos = size_t(-1);
-
 }  // namespace aa
 
 namespace aa::noexport {

--- a/tests/test_anyany.cpp
+++ b/tests/test_anyany.cpp
@@ -931,8 +931,6 @@ void anyany_interface_alias_tests() {
   AA_IA_TEST(aa::destroy);
   AA_IA_TEST(aa::destroy, aa::destroy, aa::type_info);
   AA_IA_TEST(aa::call<int()>, aa::equal_to, aa::type_info);
-#undef AA_AI_TEST
-
   using a = aa::interface_alias<aa::destroy, aa::type_info>;
   using b = aa::interface_alias<>;
   using c = aa::interface_alias<a, b>;
@@ -956,6 +954,7 @@ void anyany_interface_alias_tests() {
   static_assert(!aa::compound_method<aa::type_list<float>>);
   static_assert(!aa::compound_method<aa::type_list<aa::destroy, aa::type_info, float>>);
 #endif
+#undef AA_IA_TEST
 }
 void anyany_concepts_test() {
   anyany_interface_alias_tests<aa::any_with>();

--- a/tests/test_anyany.cpp
+++ b/tests/test_anyany.cpp
@@ -156,6 +156,9 @@ TEST(constructors) {
     a.validate();
     error_if(a(correct_float) != correct_val);
     auto copy = a;
+    swap(a, a);
+    a.validate();
+    error_if(a != copy);
     copy.validate();
     error_if(!copy.has_value());
     error_if(copy(correct_float) != correct_val);
@@ -191,10 +194,14 @@ TEST(constructors) {
   using test_types_pack =
       aa::type_list<empty, empty_non_trivial, small_trivial, small_non_trivial, big_trivial, big_non_trivial>;
   repeat_test_for(test_types_pack{});
+  auto seed = std::random_device{}();
+  std::cout << "current random seed: " << seed << std::endl;
+  std::mt19937 gen{seed};
+  std::bernoulli_distribution dist(0.9);
   auto test_swap = [&]<typename Any>(std::type_identity<Any>, auto v1, auto v2) {
-    Any a = v1;
+    Any a = dist(gen) ? Any{v1} : Any{};
     auto a_copy = a;
-    Any b = v2;
+    Any b = dist(gen) ? Any{v2} : Any{};
     auto b_copy = b;
     auto id1 = a.type_descriptor();
     auto id2 = b.type_descriptor();


### PR DESCRIPTION
in theory swap specialization avoids calling the destructor (which is non-optimizable) and is very efficient when both values are allocated.
But in practice, most of the values are not allocated, so first I made a benchmark