### PR TITLE
Allow non default constructible allocators

### DIFF
--- a/include/anyany/anyany.hpp
+++ b/include/anyany/anyany.hpp
@@ -1609,15 +1609,15 @@ template <typename Alloc, size_t SooS, anyany_simple_method_concept... Methods>
 auto insert_into_basic_any(type_list<Methods...>) {
   // if user provides 'destroy' Method, then use it
   if constexpr (noexport::contains_v<destroy, Methods...>)
-    return basic_any<Alloc, SooS, Methods...>{};
+    return std::type_identity< basic_any<Alloc, SooS, Methods...> >{};
   else
-    return basic_any<Alloc, SooS, destroy, Methods...>{};
+    return std::type_identity< basic_any<Alloc, SooS, destroy, Methods...> >{};
 }
 // if user provides 'destroy' as first Method, then i need to duplicate it
 // (so basic any do not removes it as utility Method)
 template <typename Alloc, size_t SooS, anyany_simple_method_concept... Methods>
 auto insert_into_basic_any(type_list<destroy, Methods...>)
-    -> basic_any<Alloc, SooS, destroy, destroy, Methods...>;
+    -> std::type_identity< basic_any<Alloc, SooS, destroy, destroy, Methods...> >;
 
 template <typename Alloc, size_t SooS, anyany_method_concept... Methods>
 auto flatten_into_basic_any(type_list<Methods...>) {
@@ -1636,7 +1636,7 @@ auto get_interface_of(const basic_any<Alloc, SooS, destroy, Methods...>&) -> run
 }  // namespace noexport
 
 template <typename Alloc, size_t SooS, anyany_method_concept... Methods>
-using basic_any_with = decltype(noexport::flatten_into_basic_any<Alloc, SooS>(type_list<Methods...>{}));
+using basic_any_with = typename decltype(noexport::flatten_into_basic_any<Alloc, SooS>(type_list<Methods...>{}))::type;
 
 template <anyany_method_concept... Methods>
 using any_with = basic_any_with<default_allocator, default_any_soos, Methods...>;


### PR DESCRIPTION
I ran into an issue when trying to use custom allocators which are non-default constructible. Looking into the compilation errors that resulted, it appears that fundamentally the library should have no issue with it, and it's just some metaprogramming utilities that are problematic. In particular, `insert_into_basic_any` attempts to default construct an `any`.

Since it seems this is only used for type inference, I played around and got things working with a few small changes using `std::type_identity`. Not sure if there were specific reasons for the way it was done, and I haven't tested this on anything other than MSVC, but just making a PR to demonstrate the issue and a potential fix.