### PR TITLE
Reuse memory in assign

### DIFF
--- a/include/anyany/anyany.hpp
+++ b/include/anyany/anyany.hpp
@@ -1231,7 +1231,7 @@ struct basic_any : construct_interface<basic_any<Alloc, SooSize, Methods...>, Me
 
   void replace_with(basic_any&& other) noexcept(movable_alloc()) {
     if (this == std::addressof(other))
-      return *this;
+      return;
     move_assign<exception_guarantee::strong>(other);
   }
   template <typename V, typename Self = basic_any,

--- a/include/anyany/anyany.hpp
+++ b/include/anyany/anyany.hpp
@@ -1549,7 +1549,7 @@ struct basic_any : construct_interface<basic_any<Alloc, SooSize, Methods...>, Me
     value_ptr = alloc.allocate(bytes);
     size_allocated = bytes;
   #if __cpp_exceptions
-    return scope_failure([this] { deallocate_memory(); });
+    return scope_failure{[this] { deallocate_memory(); }};
   #else
     return noexport::noop_guard{};
   #endif

--- a/include/anyany/anyany.hpp
+++ b/include/anyany/anyany.hpp
@@ -1247,7 +1247,6 @@ struct basic_any : construct_interface<basic_any<Alloc, SooSize, Methods...>, Me
     } else {
       *this = basic_any{std::forward<V>(val)};
     }
-    return *this;
   }
 
   // has strong exception guarantee

--- a/tests/test_anyany.cpp
+++ b/tests/test_anyany.cpp
@@ -1109,10 +1109,11 @@ TEST(materialize) {
     };
     error_if(std::any_of(begin(v), end(v), [&](auto& x) { return x != obj; }));
   };
-  test(aa::interface_alias<aa::destroy, aa::copy, aa::equal_to>{}, aa::default_allocator{},
+  test(aa::interface_alias<aa::destroy, aa::copy, aa::equal_to, aa::type_info_sizeof>{}, aa::default_allocator{},
        std::integral_constant<size_t, aa::default_any_soos>{});
   test(
-      aa::interface_alias<aa::equal_to, aa::destroy, aa::destroy, aa::copy_with<aa::unreachable_allocator>>{},
+      aa::interface_alias<aa::equal_to, aa::destroy, aa::destroy, aa::copy_with<aa::unreachable_allocator>, 
+      aa::type_info_sizeof>{},
       aa::unreachable_allocator{}, std::integral_constant<size_t, aa::default_any_soos>{});
   return error_count;
 }

--- a/tests/test_anyany.cpp
+++ b/tests/test_anyany.cpp
@@ -12,7 +12,7 @@
 #include <anyany/anyany.hpp>
 #include <anyany/anyany_macro.hpp>
 
-#define error_if(Cond) error_count += static_cast<bool>((Cond))
+#define error_if(Cond) if (static_cast<bool>(Cond)) throw 1 //error_count += static_cast<bool>((Cond))
 #define TEST(NAME) size_t TEST##NAME(size_t error_count = 0)
 
 template <typename Alloc = std::allocator<char>>
@@ -496,8 +496,8 @@ void noallocate_test() {
 
   any_noallocate x = 5;
   auto y = std::move(x);
-  y = x;
-  auto z = y;
+  // y = x;
+  // auto z = y; not allocation is not detectable statically without copy_with<Alloc, SooS>
 }
 #if __cplusplus >= 202002L
 using any_compare = aa::any_with<aa::copy, aa::equal_to, aa::spaceship, aa::move>;
@@ -1112,9 +1112,9 @@ TEST(materialize) {
   test(aa::interface_alias<aa::destroy, aa::copy, aa::equal_to, aa::type_info_sizeof>{}, aa::default_allocator{},
        std::integral_constant<size_t, aa::default_any_soos>{});
   test(
-      aa::interface_alias<aa::equal_to, aa::destroy, aa::destroy, aa::copy_with<aa::unreachable_allocator>, 
+      aa::interface_alias<aa::equal_to, aa::destroy, aa::destroy, aa::copy_with<std::allocator<char>>, 
       aa::type_info_sizeof>{},
-      aa::unreachable_allocator{}, std::integral_constant<size_t, aa::default_any_soos>{});
+      std::allocator<char>{}, std::integral_constant<size_t, aa::default_any_soos>{});
   return error_count;
 }
 namespace tmn {
@@ -1582,9 +1582,24 @@ int main() {
   set.emplace(5);
   set.emplace(5.);
   srand(time(0));
-  return TESTconstructors() + TESTany_cast() + TESTany_cast2() + TESTinvoke() + TESTcompare() +
-         TESTtype_descriptor_and_plugins_interaction() + TESTspecial_member_functions() + TESTptr_behavior() +
-         TESTtransmutate_ctors() + TESTstateful() + TESTsubtable_ptr() + TESTmaterialize() +
-         TESTruntime_reflection() + TESTcustom_unique_ptr() + TESTstrange_allocs() +
-         TESTalways_allocated_any() + TESTnon_default_constructible_allocs() + TESTzero_sized_any();
+  size_t error_count = 0;
+  error_count += TESTconstructors();
+  error_count += TESTany_cast();
+  error_count += TESTany_cast2();
+  error_count += TESTinvoke();
+  error_count += TESTcompare();
+  error_count += TESTtype_descriptor_and_plugins_interaction();
+  error_count += TESTspecial_member_functions();
+  error_count += TESTptr_behavior();
+  error_count += TESTtransmutate_ctors();
+  error_count += TESTstateful();
+  error_count += TESTsubtable_ptr();
+  error_count += TESTmaterialize();
+  error_count += TESTruntime_reflection();
+  error_count += TESTcustom_unique_ptr();
+  error_count += TESTstrange_allocs();
+  error_count += TESTalways_allocated_any();
+  error_count += TESTnon_default_constructible_allocs();
+  error_count += TESTzero_sized_any();
+  return error_count;
 }

--- a/tests/test_anyany.cpp
+++ b/tests/test_anyany.cpp
@@ -11,7 +11,7 @@
 #define ANYANY_ASSUME_NO_DLLS
 #include <anyany/anyany.hpp>
 #include <anyany/anyany_macro.hpp>
-
+// TODO return
 #define error_if(Cond) if (static_cast<bool>(Cond)) throw 1 //error_count += static_cast<bool>((Cond))
 #define TEST(NAME) size_t TEST##NAME(size_t error_count = 0)
 


### PR DESCRIPTION
* adds reusing memory in assigments and emplace
* adds 'replace_with_bytes' (effectively reserve) 'replace_with' (assing with strong exception guarantee)
* removes strong exception guarantee from assignments (now basic guarantee), because its too much to not reuse memory, problem very similar to std::variant::valueless_by_exception

Maybe:
* copy_with deprecated (not depends on Alloc and SooS), because of that `materialization` and copy assign/copy ctor cannot detect if they require allocation staticaly, so `aa::unreachable_alloc` less usable
